### PR TITLE
Rework API to use baseview WindowOpenOptions directly.

### DIFF
--- a/bevy_baseview_plugin/Cargo.toml
+++ b/bevy_baseview_plugin/Cargo.toml
@@ -8,19 +8,26 @@ description = "A baseview window and input backend for Bevy Engine"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy", "baseview", "gui"]
 
+[features]
+default = []
+# Enables opengl contexts in baseview. Offered purely for compatibility, as bevy
+# relies heavily on wgpu by default.
+baseviewgl = []
+
+
 [dependencies]
-# baseview = { path = "../baseview" }
+# baseview = { path = "../../baseview" }
 baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "eae4033e7d2cc9c31ccaa2794d5d08eedf2f510c" }
 crossbeam = { version = "0.8.*" }
 crossbeam-channel = { version = "0.5.*" }
 lazy_static = "1.4.0"
 raw-window-handle = "0.4.2"
-# bevy = { path = "../bevy", version = "0.8.*" }
+# bevy = { path = "../../bevy", version = "0.8.*" }
 bevy = { version = "0.8.*" }
 log = "0.4.17"
 keyboard-types = { version = "0.6.1", default-features = false }
 
 [dev-dependencies]
-# bevy = { path = "../bevy", version = "0.8.*" }
+# bevy = { path = "../../bevy", version = "0.8.*" }
 bevy = { version = "0.8.*" }
 bevy_baseview_standalone_helper = { path = "../bevy_baseview_standalone_helper" }

--- a/bevy_baseview_plugin/examples/shapes.rs
+++ b/bevy_baseview_plugin/examples/shapes.rs
@@ -9,10 +9,15 @@ fn main() {
     bevy_baseview_standalone_helper::run_app(create_app);
 }
 
-fn create_app(parent_win: ParentWin, phy_width: u32, phy_height: u32) -> AppProxy {
+fn create_app(parent_win: ParentWin, width: f64, height: f64) -> AppProxy {
     // Initailize the app.
     let mut app = App::new();
-    let proxy = attach_to(&mut app, phy_width, phy_height, parent_win);
+    let window_open_options = baseview::WindowOpenOptions {
+        title: "Shapes example".to_string(),
+        size: baseview::Size::new(width, height),
+        scale: baseview::WindowScalePolicy::SystemScaleFactor,
+    };
+    let proxy = attach_to(&mut app, &window_open_options, parent_win);
     app.add_plugins(DefaultBaseviewPlugins)
         .add_plugin(bevy::log::LogPlugin::default())
         .add_startup_system(setup)

--- a/bevy_baseview_standalone_helper/src/lib.rs
+++ b/bevy_baseview_standalone_helper/src/lib.rs
@@ -14,17 +14,18 @@ use winit::{
 
 use bevy_baseview_plugin::{AppProxy, ParentWin};
 
-const PHY_WIDTH: u32 = 500;
-const PHY_HEIGHT: u32 = 400;
+// Window size (logical).
+const WINDOW_WIDTH: f64 = 500.0;
+const WINDOW_HEIGHT: f64 = 400.0;
 
-struct AppWrapper<F: Fn(ParentWin, u32, u32) -> AppProxy> {
+struct AppWrapper<F: Fn(ParentWin, f64, f64) -> AppProxy> {
     initialized: AtomicBool,
     parent_win: ParentWin,
     create_app: F,
     app: Option<AppProxy>,
 }
 
-impl<F: Fn(ParentWin, u32, u32) -> AppProxy> AppWrapper<F> {
+impl<F: Fn(ParentWin, f64, f64) -> AppProxy> AppWrapper<F> {
     pub fn new(raw_window_handle: RawWindowHandle, create_app: F) -> Self {
         let parent_win = ParentWin::from(raw_window_handle);
         let initialized = AtomicBool::new(false);
@@ -49,8 +50,8 @@ impl<F: Fn(ParentWin, u32, u32) -> AppProxy> AppWrapper<F> {
         {
             self.app = Some((self.create_app)(
                 self.parent_win.clone(),
-                PHY_WIDTH,
-                PHY_HEIGHT,
+                WINDOW_WIDTH,
+                WINDOW_HEIGHT,
             ));
         }
 
@@ -64,10 +65,10 @@ impl<F: Fn(ParentWin, u32, u32) -> AppProxy> AppWrapper<F> {
     }
 }
 
-pub fn run_app<F: Fn(ParentWin, u32, u32) -> AppProxy + 'static>(create_app: F) {
+pub fn run_app<F: Fn(ParentWin, f64, f64) -> AppProxy + 'static>(create_app: F) {
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new()
-        .with_inner_size(winit::dpi::PhysicalSize::new(PHY_WIDTH, PHY_HEIGHT))
+        .with_inner_size(winit::dpi::PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT))
         .build(&event_loop)
         .unwrap();
 


### PR DESCRIPTION
Replace previous "get something working" code with an actual API -- we model this API after `iced_baseview`'s approach, hoisting logical vs physical size logic up to the user and granting more flexibility to frameworks.